### PR TITLE
Emit chat events for non-translated messages to improve compatibility

### DIFF
--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -22,7 +22,7 @@ function inject(bot) {
         username = match[1];
         content = match[2];
         bot.emit('chat', username, content, message);
-      } else if (match = legalContent.match(/^(?:.+? )?(.+?) (whispers to you:|whispers) (.*)$/)) {
+      } else if (match = legalContent.match(/^(?:.+? )?(.+?) (?:whispers to you:|whispers) (.*)$/)) {
         // whispered chat
         username = match[1];
         content = match[2];

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -61,6 +61,10 @@ function inject(bot) {
       bot.emit('message', chatMessage);
       // Now parse the message type
       switch(chatMessage.translate) {
+        case undefined: {
+          parseOldMessage(chatMessage.toString());
+          break;
+        }
         case 'chat.type.text': {
           var username = chatMessage.getText(0);
           var extendedMessage = chatMessage.toString().substring(username.length).trim();


### PR DESCRIPTION
The 'chat' event is emitted only when the `chat.type.text` translation is present (on modern server versions, in `parseJsonMessage7`) but this key is not used on all server software. Instead (tested on Glowstone 1c8634, Spigot/CraftBukkit 1.7.9-R0.1), the player name and text are embedded in the same string:

```
chat packet { id: 2,
  message: '{"extra":["\\u003cplayer\\u003e foobar"],"text":""}' }
parseJsonMessage { extra: [ '<player> foobar' ], text: '' }
parseJsonMessage7 { extra: [ '<player> foobar' ], text: '' }
```

mineflayer `parseOldMessage` can already parse this string format, but it isn't called (despite the "used by minecraft <= 1.6.1 and craftbukkit >= 1.6.2" comment) since the JSON message doesn't have `translate`. This PR handles this case, calling `parseOldMessage` from `parseJsonMessage7` when needed.

Fixes the chat examples on Glowstone/Spigot/CraftBukkit in my testing (used examples/echo.js).

ref https://github.com/andrewrk/mineflayer/issues/175