### PR TITLE
Update biomes enum for MC 1.8

### DIFF
--- a/bin/generate_enums.js
+++ b/bin/generate_enums.js
@@ -95,7 +95,7 @@ function biomes(burger, cb) {
     biomeEnum[biome.id] = {
       id: biome.id,
       color: biome.color,
-      height: biome.height,
+      //height: biome.height,
       name: biome.name,
       rainfall: biome.rainfall,
       temperature: biome.temperature,

--- a/lib/enums/biomes.json
+++ b/lib/enums/biomes.json
@@ -2,10 +2,6 @@
   "0": {
     "id": 0,
     "color": 112,
-    "height": [
-      -1,
-      0.4
-    ],
     "name": "Ocean",
     "rainfall": 0.5,
     "temperature": 0.5
@@ -13,10 +9,6 @@
   "1": {
     "id": 1,
     "color": 9286496,
-    "height": [
-      0.1,
-      0.3
-    ],
     "name": "Plains",
     "rainfall": 0.4,
     "temperature": 0.8
@@ -24,10 +16,6 @@
   "2": {
     "id": 2,
     "color": 16421912,
-    "height": [
-      0.1,
-      0.2
-    ],
     "name": "Desert",
     "rainfall": 0,
     "temperature": 2
@@ -35,10 +23,6 @@
   "3": {
     "id": 3,
     "color": 6316128,
-    "height": [
-      0.3,
-      1.5
-    ],
     "name": "Extreme Hills",
     "rainfall": 0.3,
     "temperature": 0.2
@@ -46,10 +30,6 @@
   "4": {
     "id": 4,
     "color": 353825,
-    "height": [
-      0.1,
-      0.3
-    ],
     "name": "Forest",
     "rainfall": 0.8,
     "temperature": 0.7
@@ -57,10 +37,6 @@
   "5": {
     "id": 5,
     "color": 747097,
-    "height": [
-      0.1,
-      0.4
-    ],
     "name": "Taiga",
     "rainfall": 0.8,
     "temperature": 0.05
@@ -68,20 +44,12 @@
   "6": {
     "id": 6,
     "color": 522674,
-    "height": [
-      -0.2,
-      0.1
-    ],
     "name": "Swampland",
     "rainfall": 0.9,
     "temperature": 0.8
   },
   "7": {
     "id": 7,
-    "height": [
-      -0.5,
-      0
-    ],
     "name": "River",
     "rainfall": 0.5,
     "temperature": 0.5
@@ -89,10 +57,6 @@
   "8": {
     "id": 8,
     "color": 16711680,
-    "height": [
-      0.1,
-      0.3
-    ],
     "name": "Hell",
     "rainfall": 0,
     "temperature": 2
@@ -100,21 +64,13 @@
   "9": {
     "id": 9,
     "color": 8421631,
-    "height": [
-      0.1,
-      0.3
-    ],
-    "name": "Sky",
-    "rainfall": 0,
+    "name": "The End",
+    "rainfall": 0.5,
     "temperature": 0.5
   },
   "10": {
     "id": 10,
     "color": 9474208,
-    "height": [
-      -1,
-      0.5
-    ],
     "name": "FrozenOcean",
     "rainfall": 0.5,
     "temperature": 0
@@ -122,10 +78,6 @@
   "11": {
     "id": 11,
     "color": 10526975,
-    "height": [
-      -0.5,
-      0
-    ],
     "name": "FrozenRiver",
     "rainfall": 0.5,
     "temperature": 0
@@ -133,10 +85,6 @@
   "12": {
     "id": 12,
     "color": 16777215,
-    "height": [
-      0.1,
-      0.3
-    ],
     "name": "Ice Plains",
     "rainfall": 0.5,
     "temperature": 0
@@ -144,10 +92,6 @@
   "13": {
     "id": 13,
     "color": 10526880,
-    "height": [
-      0.3,
-      1.3
-    ],
     "name": "Ice Mountains",
     "rainfall": 0.5,
     "temperature": 0
@@ -155,10 +99,6 @@
   "14": {
     "id": 14,
     "color": 16711935,
-    "height": [
-      0.2,
-      1
-    ],
     "name": "MushroomIsland",
     "rainfall": 1,
     "temperature": 0.9
@@ -166,10 +106,6 @@
   "15": {
     "id": 15,
     "color": 10486015,
-    "height": [
-      -1,
-      0.1
-    ],
     "name": "MushroomIslandShore",
     "rainfall": 1,
     "temperature": 0.9
@@ -177,10 +113,6 @@
   "16": {
     "id": 16,
     "color": 16440917,
-    "height": [
-      0,
-      0.1
-    ],
     "name": "Beach",
     "rainfall": 0.4,
     "temperature": 0.8
@@ -188,10 +120,6 @@
   "17": {
     "id": 17,
     "color": 13786898,
-    "height": [
-      0.3,
-      0.8
-    ],
     "name": "DesertHills",
     "rainfall": 0,
     "temperature": 2
@@ -199,10 +127,6 @@
   "18": {
     "id": 18,
     "color": 2250012,
-    "height": [
-      0.3,
-      0.7
-    ],
     "name": "ForestHills",
     "rainfall": 0.8,
     "temperature": 0.7
@@ -210,21 +134,13 @@
   "19": {
     "id": 19,
     "color": 1456435,
-    "height": [
-      0.3,
-      0.8
-    ],
     "name": "TaigaHills",
-    "rainfall": 0.8,
-    "temperature": 0.05
+    "rainfall": 0.7,
+    "temperature": 0.2
   },
   "20": {
     "id": 20,
     "color": 7501978,
-    "height": [
-      0.2,
-      0.8
-    ],
     "name": "Extreme Hills Edge",
     "rainfall": 0.3,
     "temperature": 0.2
@@ -232,10 +148,6 @@
   "21": {
     "id": 21,
     "color": 5470985,
-    "height": [
-      0.2,
-      0.4
-    ],
     "name": "Jungle",
     "rainfall": 0.9,
     "temperature": 1.2
@@ -243,12 +155,127 @@
   "22": {
     "id": 22,
     "color": 2900485,
-    "height": [
-      1.8,
-      0.5
-    ],
     "name": "JungleHills",
     "rainfall": 0.9,
     "temperature": 1.2
+  },
+  "23": {
+    "id": 23,
+    "color": 6458135,
+    "name": "JungleEdge",
+    "rainfall": 0.8,
+    "temperature": 0.95
+  },
+  "24": {
+    "id": 24,
+    "color": 48,
+    "name": "Deep Ocean",
+    "rainfall": 0.5,
+    "temperature": 0.5
+  },
+  "25": {
+    "id": 25,
+    "color": 10658436,
+    "name": "Stone Beach",
+    "rainfall": 0.3,
+    "temperature": 0.2
+  },
+  "26": {
+    "id": 26,
+    "color": 16445632,
+    "name": "Cold Beach",
+    "rainfall": 0.3,
+    "temperature": 0.05
+  },
+  "27": {
+    "id": 27,
+    "color": 3175492,
+    "name": "Birch Forest",
+    "rainfall": 0.6,
+    "temperature": 0.6
+  },
+  "28": {
+    "id": 28,
+    "color": 2055986,
+    "name": "Birch Forest Hills",
+    "rainfall": 0.6,
+    "temperature": 0.6
+  },
+  "29": {
+    "id": 29,
+    "color": 4215066,
+    "name": "Roofed Forest",
+    "rainfall": 0.8,
+    "temperature": 0.7
+  },
+  "30": {
+    "id": 30,
+    "color": 3233098,
+    "name": "Cold Taiga",
+    "rainfall": 0.4,
+    "temperature": -0.5
+  },
+  "31": {
+    "id": 31,
+    "color": 2375478,
+    "name": "Cold Taiga Hills",
+    "rainfall": 0.4,
+    "temperature": -0.5
+  },
+  "32": {
+    "id": 32,
+    "color": 5858897,
+    "name": "Mega Taiga",
+    "rainfall": 0.8,
+    "temperature": 0.3
+  },
+  "33": {
+    "id": 33,
+    "color": 4542270,
+    "name": "Mega Taiga Hills",
+    "rainfall": 0.8,
+    "temperature": 0.3
+  },
+  "34": {
+    "id": 34,
+    "color": 5271632,
+    "name": "Extreme Hills+",
+    "rainfall": 0.3,
+    "temperature": 0.2
+  },
+  "35": {
+    "id": 35,
+    "color": 12431967,
+    "name": "Savanna",
+    "rainfall": 0,
+    "temperature": 1.2
+  },
+  "36": {
+    "id": 36,
+    "color": 10984804,
+    "name": "Savanna Plateau",
+    "rainfall": 0,
+    "temperature": 1
+  },
+  "37": {
+    "id": 37,
+    "color": 14238997,
+    "name": "Mesa",
+    "rainfall": 0.5,
+    "temperature": 2.0
+  },
+  "38": {
+    "id": 38,
+    "color": 11573093,
+    "name": "Mesa Plateau F",
+    "rainfall": 0.5,
+    "temperature": 2.0
+  },
+  "39": {
+    "id": 39,
+    "color": 13274213,
+    "name": "Redwood Taiga Hills M",
+    "rainfall": 0.5,
+    "temperature": 2.0
   }
 }


### PR DESCRIPTION
MC 1.8 update for lib/enums/biomes.json (probably the simplest of the enums). Based on burger.json from https://github.com/deathcap/Burger/tree/mc18 through `bin/generate_enums.java`, with the following caveats:

* Removed biome.height - does anyone know what this was for? (http://minecraft.gamepedia.com/Biome has no mention of a height property, the old pre-1.8 Burger had it but is not clear where in 1.8 the height comes from, if anywhere). In any case, nothing else seems to reference this value, I suspect it is fairly safe to remove.
* Some of the temperatures and rainfall values were not specified in the constructors for some reason (couldn't get Burger to extract), so I used http://minecraft.gamepedia.com/Biome and https://github.com/erich666/Mineways/blob/master/Win/biomes.cpp to fill in the gaps
* "Modified" biomes (128 + original ID) are not included, these appear to be handled differently (highly dynamic, may need to be analyzed manually, or dumped at runtime)
* Other enums not yet updated, will require more work to identify the structure for extraction (so far: https://gist.github.com/deathcap/6efd375e010a005040f8)