### PR TITLE
Fix bot.players

### DIFF
--- a/examples/chatterbox.js
+++ b/examples/chatterbox.js
@@ -12,7 +12,7 @@ bot.on('login', function() {
   console.log("settings", bot.settings);
 });
 bot.on('time', function() {
-  console.log("current time", bot.time);
+  //console.log("current time", bot.time);
 });
 bot.on('playerJoined', function(player) {
   bot.chat("hello, " + player.username + "! welcome to the server.");

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -335,10 +335,10 @@ function inject(bot) {
       if(packet.action === 0) {
         // New Player
         if(!player) {
-          player = bot.players[packet.playerName] = { username: packet.playerName, ping: packet.ping };
+          player = bot.players[item.name] = { username: item.name, ping: item.ping };
           bot.emit('playerJoined', player);
           // Just an Update
-        } else player.ping = packet.ping;
+        } else player.ping = item.ping;
 
         player.entity = playerEntity;
       } else if (packet.action === 1) {
@@ -350,7 +350,7 @@ function inject(bot) {
       } else if (packet.action === 4) {
         // Player has parted
         player.entity = null;
-        delete bot.players[packet.playerName];
+        delete bot.players[item.name];
         bot.emit('playerLeft', player);
       }
     });

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -107,7 +107,8 @@ function inject(bot) {
     return resultSet;
   }
 
-  bot.players = {}
+  bot.players = {};
+  bot.uuidToUsername = {};
   bot.entities = {};
 
   bot.client.once('login', function(packet) {
@@ -142,7 +143,7 @@ function inject(bot) {
     // spawn named entity
     var entity = fetchEntity(packet.entityId);
     entity.type = 'player';
-    entity.username = packet.playerName;
+    entity.username = bot.uuidToUsername[packet.playerUUID];
     entity.uuid = packet.playerUUID;
     entity.dataBlobs = packet.data;
     entity.position.set(packet.x / 32, packet.y / 32, packet.z / 32);
@@ -150,12 +151,8 @@ function inject(bot) {
     entity.pitch = conv.fromNotchianPitchByte(packet.pitch);
     entity.height = NAMED_ENTITY_HEIGHT;
     entity.metadata = parseMetadata(packet.metadata);
-    if(!bot.players[entity.username]) {
-      bot.players[entity.username] = {
-        username: entity.username,
-        ping: 999,
-        entity: entity
-      };
+    if(!bot.players[entity.username].entity) {
+      bot.players[entity.username].entity = entity;
     }
     bot.emit('entitySpawn', entity);
   });
@@ -223,6 +220,7 @@ function inject(bot) {
       entity.isValid = false;
       if(entity.username && bot.players[entity.username]) {
         bot.players[entity.username].entity = null;
+        bot.uuidToUsername[bot.players[entity.username].entity.uuid] = null;
       }
       delete bot.entities[id];
     });
@@ -335,7 +333,8 @@ function inject(bot) {
       if(packet.action === 0) {
         // New Player
         if(!player) {
-          player = bot.players[item.name] = { username: item.name, ping: item.ping };
+          player = bot.players[item.name] = { username: item.name, ping: item.ping , uuid: item.UUID};
+          bot.uuidToUsername[item.UUID]=item.name;
           bot.emit('playerJoined', player);
           // Just an Update
         } else player.ping = item.ping;
@@ -351,6 +350,7 @@ function inject(bot) {
         // Player has parted
         player.entity = null;
         delete bot.players[item.name];
+        delete bot.uuidToUsername[item.UUID]
         bot.emit('playerLeft', player);
       }
     });

--- a/lib/plugins/spawn_point.js
+++ b/lib/plugins/spawn_point.js
@@ -5,7 +5,7 @@ module.exports = inject;
 function inject(bot) {
   bot.spawnPoint = new Vec3(0, 0, 0);
   bot.client.on('spawn_position', function(packet) {
-    bot.spawnPoint.set(packet.x, packet.y, packet.z);
+    bot.spawnPoint=new Vec3(packet.location.x,packet.location.y,packet.location.z);
     bot.emit('game');
   });
 }


### PR DESCRIPTION
This is only the first commit of the fixing of bot.players, maybe don't merge it yet.

What changed : 
* players now have a UUID
* packets often don't give the username anymore, only the UUID

bot.players was previously indexed by the player name, it should now probably be indexed by the UUID. A uuidToUsername function and a usernameToUuid function might be useful.
This means all mention of bot.players need to be changed throughout the code.