### PR TITLE
Fix #219 : fix updating position

### DIFF
--- a/examples/digger.js
+++ b/examples/digger.js
@@ -69,7 +69,7 @@ function build() {
   bot.on('move', placeIfHighEnough);
   
   function placeIfHighEnough() {
-    if (bot.entity.position.y > jumpY+0.1) {
+    if (bot.entity.position.y > jumpY) {
       bot.placeBlock(targetBlock, vec3(0, 1, 0));
       bot.setControlState('jump', false);
       bot.removeListener('move', placeIfHighEnough);

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -176,7 +176,6 @@ function inject(bot) {
       }
     }
 
-    bot.emit('move');
   }
 
   function collisionInRange(boundingBoxMin, boundingBoxMax) {
@@ -226,6 +225,8 @@ function inject(bot) {
     packet.yaw = conv.toNotchianYaw(entity.yaw);
     packet.pitch = conv.toNotchianPitch(entity.pitch);
     bot.client.write('position_look', packet);
+
+    bot.emit('move');
   }
 
   function sendPosition() {
@@ -298,7 +299,6 @@ function inject(bot) {
     bot.entity.yaw = yaw;
     bot.entity.pitch = pitch;
     if (force) lastSentYaw = yaw;
-    bot.emit("move")
   };
 
   bot.lookAt = function(point, force) {


### PR DESCRIPTION
bot.emit('move'); must be sent only after the packet position_look has been sent : only sending that packet actually change the position. Remove now unnecessary hack from digger.js.