### PR TITLE
Continue fixing crafting (#144) : the crafting slots need to be emptied after a craftOnce

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -569,6 +569,8 @@ function inject(bot) {
       }
       function updateOutShape() {
         if (! recipe.outShape) {
+          for(i=1;i<=w*h;i++)
+            window.updateSlot(i,null);
           closeTheWindow();
           return;
         }


### PR DESCRIPTION
I think it fixes #144 actually, but it needs a little more testing. Anyway, ready to merge.