### PR TITLE
Remove the obsolete Block 'add' field, minor cleanup

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -36,7 +36,6 @@
       - [block.light](#blocklight)
       - [block.skyLight](#blockskylight)
       - [block.hardness](#blockhardness)
-      - [block.add](#blockadd)
       - [block.biome](#blockbiome)
       - [block.signText](#blocksigntext)
       - [block.painting](#blockpainting)
@@ -378,8 +377,6 @@ See http://www.minecraftwiki.net/wiki/Data_values#Data
 #### block.skyLight
 
 #### block.hardness
-
-#### block.add
 
 #### block.biome
 

--- a/lib/block.js
+++ b/lib/block.js
@@ -8,7 +8,6 @@ function Block(type, biomeId) {
   this.metadata = 0;
   this.light = 0;
   this.skyLight = 0;
-  this.add = 0;
   this.biome = new Biome(biomeId);
   this.position = null;
 

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -102,7 +102,6 @@ function inject(bot) {
     block.metadata = blockType & 0x0f;
     block.light = nib(column.light);
     block.skyLight = nib(column.skyLight);
-    block.add = nib(column.add);
     block.position = loc.floored;
     block.signText = signs[loc.floored];
     block.painting = paintingsByPos[loc.floored];
@@ -303,7 +302,6 @@ function Column() {
   this.blockType = new Array(16);
   this.light = new Array(16);
   this.skyLight = new Array(16);
-  this.add = new Array(16);
   this.biome = null;
 }
 

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -301,8 +301,6 @@ function nibble(wholeByte, low) {
 
 function Column() {
   this.blockType = new Array(16);
-  // TODO : Is this part of the public API ?
-  //this.metadata = new Array(16);
   this.light = new Array(16);
   this.skyLight = new Array(16);
   this.add = new Array(16);

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -92,7 +92,7 @@ function inject(bot) {
     var column = columns[key];
     // null column means chunk not loaded
     if (! column) return null;
-    var blockType = bite(column.blockType);
+    var blockType = double_bite(column.blockType);
     var nibbleIndex = loc.blockIndex >> 1;
     var lowNibble = loc.blockIndex % 2 === 1;
 
@@ -109,7 +109,7 @@ function inject(bot) {
 
     return block;
 
-    function bite(array) {
+    function double_bite(array) {
       var buf = array[loc.chunkYIndex];
       return buf ? buf.readUInt16LE(loc.blockIndex * 2) : 0;
     }


### PR DESCRIPTION
This was technically part of the API but could only be reached with custom block IDs (>255, unlikely without https://github.com/PrismarineJS/node-minecraft-protocol/issues/114), and it wasn't populated (either in `Block` or `Column`) since the MC 1.8 update. With the existing chunk parsing code, `block.type` is already up to 12-bits (`blockType >> 4`), incorporating the old 4-bit `add` field.