### PR TITLE
BungeeCord: Support receiving multiple exit packets for the same user

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -347,10 +347,12 @@ function inject(bot) {
         // TODO: update display name
       } else if (packet.action === 4) {
         // Player has parted
-        player.entity = null;
-        delete bot.players[item.name];
-        delete bot.uuidToUsername[item.UUID];
-        bot.emit('playerLeft', player);
+        if (player) {
+          player.entity = null;
+          delete bot.players[item.name];
+          delete bot.uuidToUsername[item.UUID];
+          bot.emit('playerLeft', player);
+        }
       }
     });
   });


### PR DESCRIPTION
BungeeCord seems to send multiple exit packets for each leaving user. This produces a crash. 

Log example:

```
MC-PROTO: 3734 New-styling packet
MC-PROTO: 3734 writing packetId play.position_look (0x6)
MC-PROTO: 3734 { x: -69.5, y: 73.001, z: 246.5, onGround: true, yaw: 0, pitch: 0 }
MC-PROTO: 3734 read packetId play.player_info (0x38)
MC-PROTO: 3734 { id: 56,
  state: 'play',
  action: 4,
  length: 1,
  data: [ { UUID: [Object] } ] }
MC-PROTO: 3734 read packetId play.update_time (0x3)
MC-PROTO: 3734 { id: 3, state: 'play', age: [ 0, 52489 ], time: [ 0, 52489 ] }
MC-PROTO: 3734 New-styling packet
MC-PROTO: 3734 writing packetId play.position_look (0x6)
MC-PROTO: 3734 { x: -69.5, y: 73.001, z: 246.5, onGround: true, yaw: 0, pitch: 0 }
MC-PROTO: 3734 New-styling packet
MC-PROTO: 3734 writing packetId play.position_look (0x6)
MC-PROTO: 3734 { x: -69.5, y: 73.001, z: 246.5, onGround: true, yaw: 0, pitch: 0 }
MC-PROTO: 3734 New-styling packet
MC-PROTO: 3734 writing packetId play.position_look (0x6)
MC-PROTO: 3734 { x: -69.5, y: 73.001, z: 246.5, onGround: true, yaw: 0, pitch: 0 }
MC-PROTO: 3734 New-styling packet
MC-PROTO: 3734 writing packetId play.position_look (0x6)
MC-PROTO: 3734 { x: -69.5, y: 73.001, z: 246.5, onGround: true, yaw: 0, pitch: 0 }
MC-PROTO: 3734 read packetId play.player_info (0x38)
MC-PROTO: 3734 { id: 56,
  state: 'play',
  action: 4,
  length: 1,
  data: [ { UUID: [Object] } ] }

~/src/mineflayer/lib/plugins/entities.js:351
        player.entity = null;
                      ^
TypeError: Cannot set property 'entity' of null
    at ~/src/mineflayer/lib/plugins/entities.js:351:23
    at Array.forEach (native)
    at Client.<anonymous> (~/src/mineflayer/lib/plugins/entities.js:329:17)
    at Client.emit (events.js:95:17)
    at afterParse (~/src/mineflayer/node_modules/minecraft-protocol/dist/client.js:99:10)
    at parseNewStylePacket (~/src/mineflayer/node_modules/minecraft-protocol/dist/protocol.js:1075:5)
    at prepareParse (~/src/mineflayer/node_modules/minecraft-protocol/dist/client.js:115:9)
    at Socket.<anonymous> (~/src/mineflayer/node_modules/minecraft-protocol/dist/client.js:126:5)
    at Socket.emit (events.js:95:17)
    at Socket.<anonymous> (_stream_readable.js:764:14)
```

Checking the `player` variable fixes the problem.