### PR TITLE
Fix stopDigging() block_dig packet block location

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -39,9 +39,7 @@ function inject(bot) {
       waitTimeout = null;
       bot.client.write('block_dig', {
         status: 1, // cancel digging
-        x: bot.targetDigBlock.position.x,
-        y: bot.targetDigBlock.position.y,
-        z: bot.targetDigBlock.position.z,
+        location: bot.targetDigBlock.position,
         face: 1, // hard coded to always dig from the top
       });
       var block = bot.targetDigBlock;


### PR DESCRIPTION
The `block_dig` packet now takes a `location` field instead of individual x,y,z fields. The start digging packet was updated but not stop digging; this PR fixes that.