### PR TITLE
Add _chunkColumn for direct chunk data access (not stable API)

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -118,6 +118,11 @@ function inject(bot) {
     }
   }
 
+  function chunkColumn(x, z) {
+    var key = columnKeyXZ(x, z);
+    return columns[key];
+  }
+
   function emitBlockUpdate(oldBlock, newBlock) {
     bot.emit("blockUpdate", oldBlock, newBlock);
     var position = oldBlock ? oldBlock.position :
@@ -273,6 +278,7 @@ function inject(bot) {
   });
 
   bot.blockAt = blockAt;
+  bot._chunkColumn = chunkColumn;
   bot._updateBlock = updateBlock;
 }
 


### PR DESCRIPTION
Useful for clients to access the chunk data as efficiently as possible, but with the tradeoff of not necessarily being compatible across protocol versions (unlike blockAt, which is slower but more compatible). Prefixed with an underscore "_chunkColumn" to indicate this is not part of the stable API.

see https://github.com/deathcap/voxel-clientmc/issues/14#issuecomment-87570052
and https://github.com/andrewrk/mineflayer/issues/246