### PR TITLE
Add block break progress events

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -204,6 +204,8 @@
       - ["noteHeard" (block, instrument, pitch)](#noteheard-block-instrument-pitch)
       - ["pistonMove" (block, isPulling, direction)](#pistonmove-block-ispulling-direction)
       - ["chestLidMove" (block, isOpen)](#chestlidmove-block-isopen)
+      - ["blockBreakProgressObserved" (block, destroyStage)](#blockbreakprogressobserved-block-destroystage)
+      - ["blockBreakProgressEnd" (block)](#blockbreakprogressend-block)
       - ["diggingCompleted" (block)](#diggingcompleted-block)
       - ["diggingAborted" (block)](#diggingaborted-block)
       - ["move"](#move)
@@ -1084,6 +1086,20 @@ Fires when a note block goes off somewhere.
 #### "pistonMove" (block, isPulling, direction)
 
 #### "chestLidMove" (block, isOpen)
+
+#### "blockBreakProgressObserved" (block, destroyStage)
+
+Fires when the client observes a block in the process of being broken.
+
+ * `block`: a Block instance, the block being broken
+ * `destroyStage`: integer corresponding to the destroy progress (0-9)
+
+#### "blockBreakProgressEnd" (block)
+
+Fires when the client observes a block stops being broken.
+This occurs whether the process was completed or aborted.
+
+ * `block`: a Block instance, the block no longer being broken
 
 #### "diggingCompleted" (block)
 

--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -16,4 +16,18 @@ function inject(bot) {
       bot.emit('chestLidMove', block, packet.byte2);
     }
   });
+
+  bot.client.on('block_break_animation', function(packet) {
+    var destroyStage = packet.destroyStage;
+    var pt = new Vec3(packet.location.x, packet.location.y, packet.location.z);
+    var block = bot.blockAt(pt);
+
+    if (destroyStage < 0 || destroyStage > 9) {
+      // http://wiki.vg/Protocol#Block_Break_Progress
+      // "0-9 to set it, any other value to remove it"
+      bot.emit('blockBreakProgressEnd', block);
+    } else {
+      bot.emit('blockBreakProgressObserved', block, destroyStage);
+    }
+  });
 }


### PR DESCRIPTION
Adds two new events to the API to allow bots to observe block break progress animations. These are sent while players mine blocks, and when they stop.