### PR TITLE
Add sound effect event

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -201,6 +201,7 @@
       - ["blockUpdate:(x, y, z)" (oldBlock, newBlock)](#blockupdatex-y-z-oldblock-newblock)
       - ["chunkColumnLoad" (point)](#chunkcolumnload-point)
       - ["chunkColumnUnload" (point)](#chunkcolumnunload-point)
+      - ["soundEffectHeard" (soundName, position, volume, pitch)](#soundeffectheard-soundname-position-volume-pitch)
       - ["noteHeard" (block, instrument, pitch)](#noteheard-block-instrument-pitch)
       - ["pistonMove" (block, isPulling, direction)](#pistonmove-block-ispulling-direction)
       - ["chestLidMove" (block, isOpen)](#chestlidmove-block-isopen)
@@ -1067,6 +1068,14 @@ Note that `oldBlock` may be `null`.
 Fires when a chunk has updated. `point` is the coordinates to the corner
 of the chunk with the smallest x, y, and z values.
 
+#### "soundEffectHeard" (soundName, position, volume, pitch)
+
+Fires when the client hears a sound effect.
+
+ * `soundName`: name of the sound effect
+ * `position`: a Vec3 instance where the sound originates
+ * `volume`: floating point volume, 1.0 is 100%
+ * `pitch`: integer pitch, 63 is 100%
 
 #### "noteHeard" (block, instrument, pitch)
 

--- a/lib/plugins/sound.js
+++ b/lib/plugins/sound.js
@@ -1,0 +1,15 @@
+var Vec3 = require('vec3').Vec3;
+
+module.exports = inject;
+
+function inject(bot) {
+  bot.client.on('named_sound_effect', function(packet) {
+    var soundName = packet.soundName;
+    var pt = new Vec3(packet.x / 8, packet.y / 8, packet.z / 8);
+    var volume = packet.volume;
+    var pitch = packet.pitch;
+
+    bot.emit('soundEffectHeard', soundName, pt, volume, pitch);
+  });
+  // TODO: world_particles sound effects
+}


### PR DESCRIPTION
Adds a new API event for sound effects, `soundEffectHeard`, comparable to `noteHeard`. 

Included in a new plugin 'sound.js' (the sound effects are more general than block_actions, seemed fitting to keep separate). This PR doesn't include the world_particles (0x28 packet) sound effects, only 0x29 named_sound_effect, but they could be added later in this same plugin.

Known sound effect names: http://wiki.vg/Protocol#Sound_Effect (example: `mob.cow.say`, maybe could somehow include this list in https://github.com/PrismarineJS/minecraft-data but I'm not sure what data would be associated with it, if any - for now the name from the packet is passed directly through to the event).