### PR TITLE
Add missing varint length prefix to MC|Brand packet (GH-253)

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -21,7 +21,7 @@ function inject(bot) {
     bot.emit('login');
     bot.emit('game');
     bot.client.write('held_item_slot', {slotId: 0});
-    bot.client.write('custom_payload', {channel: 'MC|Brand', data: new Buffer('vanilla')});
+    bot.client.write('custom_payload', {channel: 'MC|Brand', data: new Buffer('\x07vanilla')}); // varint length-prefixed string TODO: encode varint, see GH-253
 
     //autoRespawn(bot);
   });


### PR DESCRIPTION
Fixes the "20:18:26 [SEVERE] Error while handling PluginMessage(channel=MC|Brand, data=[118, 97, 110, 105, 108, 108, 97]) (handler: PluginMessageHandler)
java.lang.IndexOutOfBoundsException: readerIndex(1) + length(118) exceeds writerIndex(7): UnpooledHeapByteBuf(ridx: 1, widx: 7, cap: 7/7)" error when connecting to Glowstone servers, as described in https://github.com/andrewrk/mineflayer/issues/253. 

I still think a better fix is possible (possibly, having node-minecraft-protocol know about plugin channel payload structures, or at least calling its writeString() encoding method), especially if later, mineflayer is enhanced to allow setting a custom "brand", but this PR at least fixes the immediate problem in the simplest way possible.