### PR TITLE
Delete the nmp client when connection is ended

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ Bot.prototype.connect = function(options) {
   });
   self._client.on('end', function() {
     self.emit('end');
+    delete self._client;
   });
   for (var pluginName in plugins) {
     plugins[pluginName](self, options);
@@ -67,4 +68,5 @@ Bot.prototype.connect = function(options) {
 
 Bot.prototype.end = function() {
   this._client.end();
+  delete this._client;
 };


### PR DESCRIPTION
Delete the instance of the client when `end` is called. This allows the GC to clear it from memory when it next runs.