### PR TITLE
swing arm immediately when digging

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -22,6 +22,7 @@ function inject(bot) {
     var waitTime = bot.digTime(block);
     waitTimeout = setTimeout(finishDigging, waitTime);
     bot.targetDigBlock = block;
+    bot._client.write('arm_animation', {});
     swingInterval = setInterval(function() {
       bot._client.write('arm_animation', {});
     }, 350);


### PR DESCRIPTION
Nocheat kicks mineflayer if it does not send arm_animation immediately after block_dig. There is a setInterval but that will not get called if the block dig time is less than 350ms.