### PR TITLE
Check effect exists before delete

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -276,6 +276,14 @@ function inject(bot) {
     if(effect) {
       delete entity.effects[effect.id];
     }
+    else {
+      // unknown effect
+      effect = {
+        id: packet.effectId,
+        amplifier: -1,
+        duration: -1,
+      };
+    }
     bot.emit('entityEffectEnd', entity, effect);
   });
 

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -273,7 +273,9 @@ function inject(bot) {
     // remove entity effect
     var entity = fetchEntity(packet.entityId);
     var effect = entity.effects[packet.effectId];
-    delete entity.effects[effect.id];
+    if(effect) {
+      delete entity.effects[effect.id];
+    }
     bot.emit('entityEffectEnd', entity, effect);
   });
 


### PR DESCRIPTION
Fixes [#284](https://github.com/andrewrk/mineflayer/issues/284)

I was unable to reproduce the issue on a Vanilla server but it happened on a modded server right after the player spawned near a Beacon and the server removed the Speed effect.
