### PR TITLE
Look immediately when digging or activating a block

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -13,7 +13,7 @@ function inject(bot) {
   function dig(block, cb) {
     if(bot.targetDigBlock) bot.stopDigging();
     cb = cb || noop;
-    bot.lookAt(block.position);
+    bot.lookAt(block.position, true);
     bot._client.write('block_dig', {
       status: 0, // start digging
       location: block.position,

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -96,7 +96,7 @@ function inject(bot) {
 
   function activateBlock(block) {
     // TODO: tell the server that we are not sneaking while doing this
-    bot.lookAt(block.position);
+    bot.lookAt(block.position, true);
     // swing arm animation
     bot._client.write('arm_animation', {});
     // place block message

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -306,7 +306,7 @@ function inject(bot) {
     bot.entity.pitch = pitch;
     if(force) {
       lastSentYaw = yaw;
-      sendPosition()
+      sendPosition();
     }
   };
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -304,7 +304,10 @@ function inject(bot) {
   bot.look = function(yaw, pitch, force) {
     bot.entity.yaw = yaw;
     bot.entity.pitch = pitch;
-    if(force) lastSentYaw = yaw;
+    if(force) {
+      lastSentYaw = yaw;
+      sendPosition()
+    }
   };
 
   bot.lookAt = function(point, force) {


### PR DESCRIPTION
Somewhat related to #262 

I was having some trouble digging blocks on a modded server and it turned out that the server actually checks if the player is looking directly at the block when digging or interacting with blocks and it fails otherwise.

Calling look() or lookAt() before digging or interacting with a block currently doesn't work in this case, even if we set force to true, because the position update is actually sent up to 50 ms after the call and the server receives the block_dig or block_place packet before it knows we moved.

This also affects functions like activateBlock() and it causes problems when opening chests or interacting with some other blocks, it does not happen on a Vanilla server though.

A simple workaround would be to always wait for the 'move' event before proceeding but I think it's better to send the position update immediately because otherwise the documentation is misleading, it says:

> force - If present and true, skips the smooth server-side transition. Specify this to true if you need the server to know exactly where you are looking, such as for dropping items or shooting arrows.

but even when force is true you currently have to do something like this:

```javascript
bot.look(yaw, pitch, true)
bot.once('move', function() {
  // drop item, shoot arrow...
})
```
