### PR TITLE
Add ContainerWindow to support non-Vanilla plugins

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -86,6 +86,8 @@
     - [mineflayer.windows.EnchantmentTableWindow](#mineflayerwindowsenchantmenttablewindow)
     - [mineflayer.windows.BrewingStandWindow](#mineflayerwindowsbrewingstandwindow)
     - [mineflayer.windows.ContainerWindow](#mineflayerwindowscontainerwindow)
+      - [window.containerCount(itemType, [metadata])](#windowcontainercountitemtype-metadata)
+      - [window.containerItems()](#windowcontaineritems)
     - [mineflayer.Recipe](#mineflayerrecipe)
       - [Recipe.find(itemType, [metadata])](#recipefinditemtype-metadata)
       - [recipe.result](#reciperesult)

--- a/doc/api.md
+++ b/doc/api.md
@@ -85,6 +85,7 @@
     - [mineflayer.windows.DispenserWindow](#mineflayerwindowsdispenserwindow)
     - [mineflayer.windows.EnchantmentTableWindow](#mineflayerwindowsenchantmenttablewindow)
     - [mineflayer.windows.BrewingStandWindow](#mineflayerwindowsbrewingstandwindow)
+    - [mineflayer.windows.ContainerWindow](#mineflayerwindowscontainerwindow)
     - [mineflayer.Recipe](#mineflayerrecipe)
       - [Recipe.find(itemType, [metadata])](#recipefinditemtype-metadata)
       - [recipe.result](#reciperesult)
@@ -584,6 +585,20 @@ Watching `bot.inventory.on("windowUpdate")` is the best way to watch for changes
 ### mineflayer.windows.DispenserWindow
 ### mineflayer.windows.EnchantmentTableWindow
 ### mineflayer.windows.BrewingStandWindow
+### mineflayer.windows.ContainerWindow
+
+Generic window that can be opened by some non-Vanilla servers and Bukkit plugins like Essentials' /invsee.
+
+#### window.containerCount(itemType, [metadata])
+Returns how many items there are in the top section of the window.
+
+ * `itemType` - numerical id that you are looking for
+ * `metadata` - (optional) metadata value that you are looking for.
+   defaults to unspecified
+
+#### window.containerItems()
+
+Returns a list of `Item` instances from the top section of the window.
 
 ### mineflayer.Recipe
 

--- a/examples/chest.js
+++ b/examples/chest.js
@@ -34,6 +34,28 @@ bot.on('chat', function(username, message) {
     watchDispenser();
   } else if(message === "enchant") {
     watchEnchantmentTable();
+  } else if(/^invsee /.test(message)) {
+    // note: you must have the permission to use this command
+    var words = message.split(" ");
+    var username = words[1];
+    var showEquipment = words[2];
+    bot.once('windowOpen', function(window) {
+      var count = window.containerItems().length;
+      var what = showEquipment ? 'equipment' : 'inventory items';
+      if(count) {
+        bot.chat(username + "'s " + what + ":");
+        bot.chat(window.containerItems().map(itemStr).join(", "));
+      } else {
+        bot.chat(username + " has no " + what);
+      }
+    });
+    if(showEquipment) {
+      // any extra parameter triggers the "easter egg"
+      // and shows the other player's equipment
+      bot.chat('/invsee ' + username + ' 1');
+    } else {
+      bot.chat('/invsee ' + username);
+    }
   }
 });
 

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -16,6 +16,7 @@ module.exports = {
   DispenserWindow: DispenserWindow,
   EnchantmentTableWindow: EnchantmentTableWindow,
   BrewingStandWindow: BrewingStandWindow,
+  ContainerWindow: ContainerWindow,
   INVENTORY_SLOT_COUNT: INVENTORY_SLOT_COUNT,
 };
 
@@ -26,6 +27,7 @@ var windows = {
   "minecraft:dispenser": DispenserWindow,
   "minecraft:enchanting_table": EnchantmentTableWindow,
   "minecraft:brewing_stand": BrewingStandWindow,
+  "minecraft:container": ContainerWindow,
 };
 
 function createWindow(id, type, title, slotCount) {
@@ -370,3 +372,29 @@ function BrewingStandWindow(id, title, slotCount) {
 util.inherits(BrewingStandWindow, Window);
 
 BrewingStandWindow.prototype.inventorySlotStart = 5;
+
+
+function ContainerWindow(id, title, slotCount) {
+  Window.call(this, id, 6, title, slotCount);
+
+  if (isInventoryWindow() && slotCount == 40) {
+    // 4 armor slots are always excluded
+    slotCount -= 4;
+  }
+
+  this.inventorySlotStart = slotCount;
+
+  function isInventoryWindow() {
+    return title.indexOf('container.inventory') > -1;
+  }
+}
+util.inherits(ContainerWindow, Window);
+
+ContainerWindow.prototype.containerItems = function() {
+  return this.itemsRange(0, this.inventorySlotStart);
+}
+
+ContainerWindow.prototype.containerCount = function(itemType, metadata) {
+  itemType = parseInt(itemType, 10); // allow input to be a string
+  return this.countRange(0, this.inventorySlotStart, itemType, metadata);
+}


### PR DESCRIPTION
Fixes #289 

This fix is purposely generic so hopefully it will prevent crashes on non-Vanilla servers that use other Bukkit plugins that open custom windows.

I tested this on a fresh CraftBukkit install with the Essentials plugin enabled, and both `/invsee Player` (shows the player's inventory and quickbar slots) and `/invsee Player 1` (shows the player's armor) seem to work fine.

Example:
```js
bot.once('windowOpen', function(window) {
  console.log('Notch\'s inventory:');
  window.containerItems().forEach(function(item) {
    console.log(item);
  });
});
bot.chat('/invsee Notch');
```