### PR TITLE
Prevent crash when an unknown entity is spawned

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -359,6 +359,7 @@ Choices:
  * `object`
  * `global` - lightning
  * `orb` - experience orb.
+ * `other` - introduced with a recent Minecraft update and not yet recognized by Mineflayer or used by a third-party mod
 
 #### entity.username
 

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -128,13 +128,19 @@ function inject(bot) {
   bot._client.on('spawn_entity', function(packet) {
     // spawn object/vehicle
     var entity = fetchEntity(packet.entityId);
-    entity.type = 'object';
     var entityData = entitiesData[packet.type];
-    entity.objectType = entityData.displayName;
-    entity.displayName = entityData.displayName;
-    entity.entityType = entityData.id;
-    entity.name = entityData.name;
-    entity.kind = entityData.type;
+    if(entityData) {
+      entity.type = 'object';
+      entity.objectType = entityData.displayName;
+      entity.displayName = entityData.displayName;
+      entity.entityType = entityData.id;
+      entity.name = entityData.name;
+      entity.kind = entityData.type;
+    } else {
+      // unknown entity
+      entity.type = 'other';
+      entity.entityType = packet.type;
+    }
     entity.position.set(packet.x / 32, packet.y / 32, packet.z / 32);
     entity.yaw = conv.fromNotchianYawByte(packet.yaw);
     entity.pitch = conv.fromNotchianPitchByte(packet.pitch);


### PR DESCRIPTION
This is similar to what happened here: #291

There is no check that ensures we actually have the entity data before we use them. When an unknown entity is spawned, either because it was recently introduced in a new Minecraft update or because the entity type ID is used by a third-party mod, the bot crashes.

Also, is there an issue with PrismarineJS/minecraft-data or am I missing something? It seems that some entity IDs in [entities.json](https://github.com/PrismarineJS/minecraft-data/blob/master/enums/entities.json) are different from the ones reported [here](http://wiki.vg/Entities#Objects)

In my case the server sent a spawn_entity packet with type = 78, which should be an Armor Stand, but there are no entities with the same ID in that list, were some IDs changed in a protocol update?

Maybe this should be a separate issue, though.
